### PR TITLE
Adjust ECP tests to reflect changes in TLS 1.3 regarding ECP format

### DIFF
--- a/tests/suites/test_suite_ecp.data
+++ b/tests/suites/test_suite_ecp.data
@@ -171,17 +171,14 @@ ecp_tls_write_read_point:MBEDTLS_ECP_DP_SECP521R1
 ECP tls read group #1 (record too short)
 mbedtls_ecp_tls_read_group:"0313":MBEDTLS_ERR_ECP_BAD_INPUT_DATA:0:0
 
-ECP tls read group #2 (bad curve_type)
-mbedtls_ecp_tls_read_group:"010013":MBEDTLS_ERR_ECP_BAD_INPUT_DATA:0:0
-
-ECP tls read group #3 (unknown curve)
+ECP tls read group #2 (unknown curve)
 mbedtls_ecp_tls_read_group:"030010":MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE:0:0
 
-ECP tls read group #4 (OK, buffer just fits)
+ECP tls read group #3 (OK, buffer just fits)
 depends_on:MBEDTLS_ECP_DP_SECP256R1_ENABLED
 mbedtls_ecp_tls_read_group:"030017":0:256:3
 
-ECP tls read group #5 (OK, buffer continues)
+ECP tls read group #4 (OK, buffer continues)
 depends_on:MBEDTLS_ECP_DP_SECP384R1_ENABLED
 mbedtls_ecp_tls_read_group:"0300180000":0:384:3
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -929,6 +929,12 @@ void mbedtls_ecp_tls_read_group( data_t * buf, int result, int bits,
 
     mbedtls_ecp_group_init( &grp );
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    vbuf++;
+    buf->x++;
+    buf->len--;
+    record_len--;
+#endif
     ret = mbedtls_ecp_tls_read_group( &grp, &vbuf, buf->len );
 
     TEST_ASSERT( ret == result );


### PR DESCRIPTION
In `mbedtls_ecp_tls_read_group_id()`, for the same input curve, the `TLS NamedCurve ID` is not computed the same way for TLS 1.2 and 1.3.
That's because TLS 1.2 follows the `ECParameters` structure defined in https://tools.ietf.org/html/rfc4492, while TLS 1.3 got rid of the redundant curve type (always set to "named curve"), as specified here: https://tools.ietf.org/html/rfc8446#section-4.2.7.

This PR changes ECP tests to take this change in consideration, while still supporting TLS 1.2:
* Input data is changed depending on the TLS version
* One test is removed since it's not compatible with TLS 1.3 and there is a priori no way to run it for TLS 1.2 only